### PR TITLE
Fix P4.login() for `p4` >=2014.1

### DIFF
--- a/lib/p4.js
+++ b/lib/p4.js
@@ -237,8 +237,11 @@ module.exports = function(exec,path){
             args = args.join(' ');
         }
 
+        var cmdEnv = process.env;
+        cmdEnv.PASS = this.password;
+
         try{
-        return exec(command + ' ' + (args || ''), {cwd:this.cwd}, function(err, stdOut, stdErr) {
+        return exec(command + ' ' + (args || ''), {cwd: this.cwd, env: cmdEnv}, function(err, stdOut, stdErr) {
             if(err) {
                 return done(err);
             }
@@ -513,7 +516,7 @@ module.exports = function(exec,path){
         if(typeof username === 'function'){
             done = username;
         }
-        return this.runShellCommand('echo "' + this.password + '" | p4 -u "' + this.username + '" login ', done);
+        return this.runShellCommand('echo "$PASS" | p4 -u "' + this.username + '" login ', done);;
     };
 
     /**

--- a/lib/p4.js
+++ b/lib/p4.js
@@ -513,7 +513,7 @@ module.exports = function(exec,path){
         if(typeof username === 'function'){
             done = username;
         }
-        return this.runShellCommand('echo "' + this.password + '" | p4 login -u "' + this.username + '"', done);
+        return this.runShellCommand('echo "' + this.password + '" | p4 -u "' + this.username + '" login ', done);
     };
 
     /**


### PR DESCRIPTION
The p4 login command `p4 login -u <user>` is not respected by Perforce
client version 2014.1.  Fixing the order to `p4 -u <user> login`
reflects Perforce's docs better and _should_ be backwards compatible,
but I do not have an older version to confirm.

Tested against Server version 2015.1.

I know it's just a fix, but given that it may break with older p4
versions, it might be prudent to roll the major release.

Fixes #4 
